### PR TITLE
Add cache buster to query attacks

### DIFF
--- a/packages/backend/src/mining/requester.ts
+++ b/packages/backend/src/mining/requester.ts
@@ -68,6 +68,9 @@ export class Requester {
     switch (attackType) {
       case "query":
         this.handleQueryParameters(requestCopy, parameters);
+        if (this.paramMiner.config.cacheBusterParameter || this.paramMiner.config.addCacheBusterParameter) {
+          this.handleCacheBusterParameter(requestCopy);
+        }
         break;
 
       case "headers":

--- a/packages/frontend/src/components/settings/AdvancedSettingsSection.tsx
+++ b/packages/frontend/src/components/settings/AdvancedSettingsSection.tsx
@@ -153,7 +153,7 @@ export const AdvancedSettingsSection = () => {
             field: "addCacheBusterParameter" as const,
             label: "Always Add Cache Buster Parameter",
             tooltip:
-              "Always add a cache buster parameter to the request for headers attack",
+              "Always add a cache buster parameter to the request for headers & query attack",
           },
         ].map(({ field, label, tooltip }) => (
           <Box key={field}>


### PR DESCRIPTION
In some cases if parameter are part of the cache key, it could be helpful to also bust the cache for an query attack