### PR TITLE
fix: Send to Replay keyboard shortcut

### DIFF
--- a/packages/frontend/src/features/sessions/components/RequestsPanel/RequestDetails/HTTPEditor/useHttpEditor.ts
+++ b/packages/frontend/src/features/sessions/components/RequestsPanel/RequestDetails/HTTPEditor/useHttpEditor.ts
@@ -88,7 +88,7 @@ export function useHttpEditor(
       event.key.toLowerCase() !== "r" ||
       (!event.metaKey && !event.ctrlKey) ||
       event.altKey ||
-      event.shiftKey ||
+      !event.shiftKey ||
       event.repeat ||
       root.value === undefined ||
       document.activeElement === null ||


### PR DESCRIPTION
Fixes #20. Changed the keyboard shortcut listener in useHttpEditor to require the Shift key, properly binding to CMD+SHIFT+R and CTRL+SHIFT+R to match Caido's default shortcuts.